### PR TITLE
Correct illegibility of content message by theming

### DIFF
--- a/gradle/changelog/theme-styling.yaml
+++ b/gradle/changelog/theme-styling.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Correct illegibility of content message by theming ([#4](https://github.com/scm-manager/scm-content-search-plugin/pull/4))

--- a/src/main/js/ContentHitRenderer.tsx
+++ b/src/main/js/ContentHitRenderer.tsx
@@ -39,11 +39,11 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 const Container = styled(Hit.Content)`
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 const FileContent = styled.div`
-  border: 1px solid #dbdbdb;
+  border: var(--scm-border);
   border-radius: 0.25rem;
 `;
 
@@ -55,7 +55,7 @@ type SyntaxHighlighting = {
   };
 };
 
-const ContentMessage: FC = ({ children }) => <div className="has-background-info-light p-4 is-size-7">{children}</div>;
+const ContentMessage: FC = ({ children }) => <pre className="p-4 is-size-7 is-family-primary">{children}</pre>;
 
 const BinaryContent: FC = () => {
   const [t] = useTranslation("plugins");


### PR DESCRIPTION
## Proposed changes

Correct illegibility of content message by theming

![Image of bugreport](https://user-images.githubusercontent.com/45232454/162916242-9ed24f82-6d50-40e2-bee2-b95a93c9b5d6.png)

The font is displayed in white on a white background. This was fixed by abandoning individual color styling and instead using the consistent pre class.
Also, the scollbar of the parent component is now only rendered when necessary and the border styling matches the theme.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
